### PR TITLE
Stop silently ignoring report errors

### DIFF
--- a/undercover.el
+++ b/undercover.el
@@ -402,7 +402,7 @@ Values of that hash are number of covers."
 
 (defun undercover-safe-report ()
   "Version of `undercover-report' that ignore errors."
-  (ignore-errors
+  (with-demoted-errors
     (undercover-report)))
 
 (defun undercover-report-on-kill ()


### PR DESCRIPTION
This hid important messages such as "Unsupported report-type" and complicated debugging.