### PR TITLE
Remove the :report-type option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,11 @@ after_success:
   $ COVERALLS_REPO_TOKEN=<your-coveralls-repo-token> cask exec ert-runner
   ```
 
-- Set `report-type` if not using [Coveralls](https://coveralls.io/):
+- If not using [Coveralls](https://coveralls.io/), compatible services (such as CodeCov) can be used by saving the report and uploading it from your pipeline:
 
   ```lisp
-  (undercover "*.el" (:report-type :codecov))
+  (undercover "*.el" (:report-file "coverage-final.json")
+                     (:send-report nil))
   ```
   
 - Set `report-file` option if you want to change report location:

--- a/undercover.el
+++ b/undercover.el
@@ -444,6 +444,8 @@ Return wildcards."
       (case (car-safe option)
         (:report-file (setq undercover--report-file-path (cadr option)))
         (:send-report (setq undercover--send-report (cadr option)))
+        ;; Note: this option is obsolete and intentionally undocumented.
+        ;; Please use :report-file and :send-report explicitly instead.
         (:report-type (case (cadr option)
                         (:coveralls)
                         (:codecov (setq undercover--report-file-path "coverage-final.json")


### PR DESCRIPTION
```
This option was confusing to the point of being harmful to
undercover.el users:

1. Specifying the option had two effects, neither of which had
   anything to do with the contents of the actual report.

2. The option was named in the same way as the
   undercover--determine-report-type function and the report-type
   parameter to undercover-report, but had nothing to do with either.

3. Out of context, the option's documentation was misleading and
   incomplete. It suggested that setting the option was all that was
   needed to make undercover.el upload the coverage report to a different
   service, when in reality additional steps (invoking the coverage
   service's upload tool) were required.

Replace the option with a suggestion to set the respective options it
affected instead, which is obvious, self-documenting, and not
significantly longer.
```
