### PR TITLE
Use absolute pathnames for `file-name-handler-alist'

### DIFF
--- a/undercover.el
+++ b/undercover.el
@@ -134,7 +134,7 @@ Example of WILDCARDS: (\"*.el\" \"subdir/*.el\" (:exclude \"exclude-*.el\"))."
 (defun undercover--edebug-files (files)
   "Use `edebug' package to instrument all macros and functions in FILES."
   (when files
-    (let ((regexp (->> files (regexp-opt) (format "/%s$"))))
+    (let ((regexp (->> (-map #'expand-file-name files) (regexp-opt) (format "^%s$"))))
       (add-to-list 'file-name-handler-alist (cons regexp 'undercover-file-handler)))))
 
 (setf (symbol-function 'undercover--stop-point-before)


### PR DESCRIPTION
Rationale:
* Suppose your project's main file is called `foo.el` and the tests are in `test/foo.el`. Currently, `undercover` will erroneously instrument the test file too, because it matches by filename, ignoring the path. I know this is not the standard setup, but this patch makes `undercover` work with it too, at zero cost.
